### PR TITLE
Remove ./tmp duplucation

### DIFF
--- a/spec/sitemapper_storage_spec.cr
+++ b/spec/sitemapper_storage_spec.cr
@@ -1,8 +1,8 @@
 require "file_utils"
 require "./spec_helper"
 
-def with_tempfile
-  yield
+def with_tempdir
+  yield("./tmp")
   if Dir.exists?("./tmp")
     FileUtils.rm_rf("./tmp")
   end
@@ -12,11 +12,11 @@ describe Sitemapper::Storage do
   describe "with local storage" do
     describe "with compress" do
       it "writes sitemap.xml.gz" do
-        with_tempfile do
+        with_tempdir do |dir|
           storage = Sitemapper::Storage.new([{"name" => "sitemap.xml", "data" => "<XML></XML>"}], :local)
-          storage.save("./tmp")
-          File.exists?("./tmp/sitemap.xml.gz").should eq true
-          File.size("./tmp/sitemap.xml.gz").should be > 1
+          storage.save(dir)
+          File.exists?("#{dir}/sitemap.xml.gz").should eq true
+          File.size("#{dir}/sitemap.xml.gz").should be > 1
         end
       end
     end
@@ -24,11 +24,11 @@ describe Sitemapper::Storage do
     describe "without compress" do
       it "writes sitemap.xml" do
         Sitemapper.configure { |c| c.compress = false }
-        with_tempfile do
+        with_tempdir do |dir|
           storage = Sitemapper::Storage.new([{"name" => "sitemap.xml", "data" => "<XML></XML>"}], :local)
-          storage.save("./tmp")
-          File.exists?("./tmp/sitemap.xml").should eq true
-          File.size("./tmp/sitemap.xml").should be > 1
+          storage.save(dir)
+          File.exists?("#{dir}/sitemap.xml").should eq true
+          File.size("#{dir}/sitemap.xml").should be > 1
         end
       end
     end


### PR DESCRIPTION
This reads just a _tiny_ bit cleaner to me, what do you think?