### PR TITLE
Add matrix testing spec support and other small tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,35 +2,47 @@ name: Sitemapper CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
     branches: "*"
 
 jobs:
   check_format:
+    strategy:
+      matrix:
+        container:
+          - crystallang/crystal:latest-alpine
     runs-on: ubuntu-latest
-    container:
-      image: crystallang/crystal:0.35.1
+    container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v1
       - name: Install shards
         run: shards install
+      - name: Cache Crystal
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/crystal
+          key: ${{ runner.os }}-${{ matrix.container }}-crystal
       - name: Format
         run: crystal tool format --check
       - name: Lint
         run: ./bin/ameba
+
   specs:
+    strategy:
+      matrix:
+        container:
+          - crystallang/crystal:latest-alpine
     runs-on: ubuntu-latest
-    container:
-      image: crystallang/crystal:0.35.1
+    container: ${{ matrix.container }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Install shards
-      run: shards install
-    - name: Cache Crystal
-      uses: actions/cache@v1
-      with:
-        path: ~/.cache/crystal
-        key: ${{ runner.os }}-crystal
-    - name: Run tests
-      run: crystal spec
+      - uses: actions/checkout@v2
+      - name: Install shards
+        run: shards install
+      - name: Cache Crystal
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/crystal
+          key: ${{ runner.os }}-${{ matrix.container }}-crystal
+      - name: Run tests
+        run: crystal spec


### PR DESCRIPTION
Added a few niceties to the test suite:

- Matrix testing against the latest crystal version. In the future, this could be expanded to include `nightly` really easily.
- Formatting changes to the YAML to align with [GitHub's examples](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions) and Prettier
- Use the crystal cache in the `check_format` job as well since we're `shards install`ing in both steps.
- Namespace the cache behind the crystal version we're testing