### PR TITLE
Move from `master` branch to stable version for `awscr-s3`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,25 +5,40 @@ on:
     branches: [master]
   pull_request:
     branches: "*"
+  schedule:
+    - cron: "0 0 * * MON"
 
 jobs:
   check_format:
     strategy:
+      fail-fast: false
       matrix:
-        container:
-          - crystallang/crystal:latest-alpine
-          - crystallang/crystal:nightly-alpine
+        crystal_version:
+          - latest
+        experimental:
+          - false
+        include:
+          - crystal_version: nightly
+            experimental: true
     runs-on: ubuntu-latest
-    container: ${{ matrix.container }}
+    continue-on-error: ${{ matrix.experimental }}
+    container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
     steps:
       - uses: actions/checkout@v1
-      - name: Install shards
-        run: shards install --ignore-crystal-version
-      - name: Cache Crystal
-        uses: actions/cache@v1
+      - name: Set up Crystal cache
+        uses: actions/cache@v2
+        id: crystal-cache
         with:
-          path: ~/.cache/crystal
-          key: ${{ runner.os }}-${{ matrix.container }}-crystal
+          path: |
+            ~/.cache/crystal
+            bin/ameba
+            lib
+          key: ${{ runner.os }}-crystal-${{ matrix.crystal_version }}-${{ hashFiles('**/shard.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-crystal-${{ matrix.crystal_version }}
+      - name: Install shards
+        if: steps.crystal-cache.outputs.cache-hit != 'true'
+        run: shards check || shards install
       - name: Format
         run: crystal tool format --check
       - name: Lint
@@ -31,20 +46,33 @@ jobs:
 
   specs:
     strategy:
+      fail-fast: false
       matrix:
-        container:
-          - crystallang/crystal:latest-alpine
-          - crystallang/crystal:nightly-alpine
+        crystal_version:
+          - latest
+        experimental:
+          - false
+        include:
+          - crystal_version: nightly
+            experimental: true
     runs-on: ubuntu-latest
-    container: ${{ matrix.container }}
+    continue-on-error: ${{ matrix.experimental }}
+    container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
     steps:
       - uses: actions/checkout@v2
-      - name: Install shards
-        run: shards install --ignore-crystal-version
-      - name: Cache Crystal
-        uses: actions/cache@v1
+      - name: Set up Crystal cache
+        uses: actions/cache@v2
+        id: crystal-cache
         with:
-          path: ~/.cache/crystal
-          key: ${{ runner.os }}-${{ matrix.container }}-crystal
+          path: |
+            ~/.cache/crystal
+            bin/ameba
+            lib
+          key: ${{ runner.os }}-crystal-${{ matrix.crystal_version }}-${{ hashFiles('**/shard.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-crystal-${{ matrix.crystal_version }}
+      - name: Install shards
+        if: steps.crystal-cache.outputs.cache-hit != 'true'
+        run: shards check || shards install
       - name: Run tests
         run: crystal spec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,13 @@ jobs:
       matrix:
         container:
           - crystallang/crystal:latest-alpine
+          - crystallang/crystal:nightly-alpine
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v1
       - name: Install shards
-        run: shards install
+        run: shards install --ignore-crystal-version
       - name: Cache Crystal
         uses: actions/cache@v1
         with:
@@ -33,12 +34,13 @@ jobs:
       matrix:
         container:
           - crystallang/crystal:latest-alpine
+          - crystallang/crystal:nightly-alpine
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v2
       - name: Install shards
-        run: shards install
+        run: shards install --ignore-crystal-version
       - name: Cache Crystal
         uses: actions/cache@v1
         with:

--- a/shard.yml
+++ b/shard.yml
@@ -11,7 +11,7 @@ license: MIT
 dependencies:
   awscr-s3:
     github: taylorfinnell/awscr-s3
-    branch: master
+    version: ~> 0.8.0
 
 development_dependencies:
   webmock:


### PR DESCRIPTION
If you use `sitemapper` with [`shrine.cr`](https://github.com/jetrockets/shrine.cr), you'll get an error in your installation:

```
Unable to satisfy the following requirements:

- `awscr-s3 (0.8.0)` required by `shard.lock`
- `awscr-s3 (branch master)` required by `sitemapper 0.7.0`
Failed to resolve dependencies
```

I'm not sure what the original reason was for using master, but the tests pass with the v0.8.0 version and will make this library a bit more stable and less subject to possibly breaking upstream changes in that shard.