### PR TITLE
Add namespace attributes for images and videos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,7 @@ name: Sitemapper CI
 
 on:
   push:
-    branches:
-      - master
+    branches: [master]
   pull_request:
   schedule:
     - cron: "0 0 * * MON"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,12 @@ name: Sitemapper CI
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
   pull_request:
-    branches: "*"
   schedule:
     - cron: "0 0 * * MON"
+  workflow_dispatch:
 
 jobs:
   check_format:

--- a/spec/sitemapper_builder_spec.cr
+++ b/spec/sitemapper_builder_spec.cr
@@ -44,7 +44,7 @@ describe Sitemapper::Builder do
       XML
 
       xml.should contain <<-XML
-      <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+      <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
       XML
 
       xml.should contain <<-XML

--- a/src/sitemapper/builder.cr
+++ b/src/sitemapper/builder.cr
@@ -1,6 +1,8 @@
 module Sitemapper
   class Builder
     XMLNS_SCHEMA = "https://www.sitemaps.org/schemas/sitemap/0.9"
+    XMLNS_VIDEO_SCHEMA = "http://www.google.com/schemas/sitemap-video/1.1"
+    XMLNS_IMAGE_SCHEMA = "http://www.google.com/schemas/sitemap-image/1.1"
 
     getter paginator
 
@@ -18,7 +20,7 @@ module Sitemapper
       @paginator.total_pages.times do |page|
         filename = filename_for_page(page)
         doc = XML.build(indent: " ", version: "1.0", encoding: "UTF-8") do |xml|
-          xml.element("urlset", xmlns: XMLNS_SCHEMA) do
+          xml.element("urlset", xmlns: XMLNS_SCHEMA, "xmlns:video": XMLNS_VIDEO_SCHEMA, "xmlns:image": XMLNS_IMAGE_SCHEMA) do
             @paginator.items(page + 1).each do |info|
               build_xml_from_info(xml, info)
             end
@@ -30,7 +32,7 @@ module Sitemapper
 
       if @use_index
         doc = XML.build(indent: " ", version: "1.0", encoding: "UTF-8") do |xml|
-          xml.element("sitemapindex", xmlns: XMLNS_SCHEMA) do
+          xml.element("sitemapindex", xmlns: XMLNS_SCHEMA, "xmlns:video": XMLNS_VIDEO_SCHEMA, "xmlns:image": XMLNS_IMAGE_SCHEMA) do
             @sitemaps.each do |sm|
               xml.element("sitemap") do
                 sitemap_name = sm["name"].to_s + (Sitemapper.config.compress ? ".gz" : "")

--- a/src/sitemapper/builder.cr
+++ b/src/sitemapper/builder.cr
@@ -1,6 +1,6 @@
 module Sitemapper
   class Builder
-    XMLNS_SCHEMA = "https://www.sitemaps.org/schemas/sitemap/0.9"
+    XMLNS_SCHEMA       = "https://www.sitemaps.org/schemas/sitemap/0.9"
     XMLNS_VIDEO_SCHEMA = "http://www.google.com/schemas/sitemap-video/1.1"
     XMLNS_IMAGE_SCHEMA = "http://www.google.com/schemas/sitemap-image/1.1"
 


### PR DESCRIPTION
Closes #16 

I kept running into errors like this when checking my sitemap that's chock full of videos:

> Namespace prefix video on thumbnail_loc is not defined

I checked Google's docs, and for both Images and Videos they say that we need to include these namespaces:
- https://developers.google.com/search/docs/advanced/sitemaps/video-sitemaps#xml-namespace
- https://developers.google.com/search/docs/advanced/sitemaps/image-sitemaps#xml-namespace

I'm sure there's something "smarter" that could be done to only add these when videos/images are present, but I don't think that the extra characters will be of much consequence.

I also wasn't sure if Bing has their own namespace or something, but I couldn't find anything on their documentation so I'm sort of assuming that the whole internet is letting Google define the namespaces.

I'm running this branch on production for LuckyCasts (https://luckycasts.com/sitemap.xml), and have verified that the Google Search Console errors are gone and browsers can parse the file too.