### PR TITLE
Chomp trailing slashes from the host

### DIFF
--- a/spec/sitemapper_builder_spec.cr
+++ b/spec/sitemapper_builder_spec.cr
@@ -111,4 +111,16 @@ describe Sitemapper::Builder do
       XML
     end
   end
+
+  describe "#generate_index" do
+    it "trims the trailing slash from the host" do
+      Sitemapper.configure { |c| c.sitemap_host = "https://sitemaps.myapp.com/" }
+      builder = Sitemapper::Builder.new(host: "http://food.com", max_urls: 100, use_index: true)
+      builder.add("/burgers")
+      builder.generate
+      data = builder.generate_index
+      data["data"].should contain("https://sitemaps.myapp.com/sitemap.xml")
+      data["data"].should contain("https://sitemaps.myapp.com/sitemap_index.xml")
+    end
+  end
 end

--- a/src/sitemapper/builder.cr
+++ b/src/sitemapper/builder.cr
@@ -42,7 +42,7 @@ module Sitemapper
           @sitemaps.each do |sm|
             xml.element("sitemap") do
               sitemap_name = sm["name"].to_s + (Sitemapper.config.compress ? ".gz" : "")
-              sitemap_url = [(Sitemapper.config.sitemap_host || @host), sitemap_name].join('/')
+              sitemap_url = [host_for_sitemap, sitemap_name].join('/')
 
               xml.element("loc") { xml.text sitemap_url }
               xml.element("lastmod") { xml.text Time.utc.to_s("%FT%X%:z") }
@@ -52,6 +52,10 @@ module Sitemapper
       end
       filename = "sitemap_index.xml"
       {"name" => filename, "data" => doc}
+    end
+
+    private def host_for_sitemap : String
+      (Sitemapper.config.sitemap_host || @host).chomp('/')
     end
 
     private def build_xml_for_page(items)


### PR DESCRIPTION
Fixes #31

This avoids your sitemap generating a host with a double trailing slash